### PR TITLE
Fix dead code: Attach fileInputRef and centralize file handling

### DIFF
--- a/components/UploadPanel.tsx
+++ b/components/UploadPanel.tsx
@@ -1,74 +1,30 @@
 "use client";
 
-import React, { useRef, useEffect, useCallback } from "react";
+import React, { useRef, useEffect } from "react";
 import Image from "next/image";
-
-interface BlobEntry {
-  id: string;
-  file: File;
-  url: string;
-  snippet: string;
-}
+import { BlobEntry } from "./types";
+import { formatBytes, isImage } from "./file-utils";
 
 interface UploadPanelProps {
   files: BlobEntry[];
-  onFilesChange: (files: BlobEntry[]) => void;
+  onUploadFiles: (files: FileList | null) => void;
+  onOpenFileDialog: () => void;
   onCopySnippet: (snippet: string) => void;
   onCopyAllSnippets: () => void;
   onDownloadSnippets: () => void;
   maxPanel: string | null;
 }
 
-function formatBytes(bytes: number) {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB", "TB"] as const;
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
-}
-
-function isImage(file: File) {
-  return file.type.startsWith("image/");
-}
-
-function snippetFor(file: File, url: string) {
-  const safeName = file.name.replace(/\]/g, ")");
-  if (isImage(file)) return `![${safeName}](${url})`;
-  return `[${safeName}](${url})`;
-}
-
 export default function UploadPanel({
   files,
-  onFilesChange,
+  onUploadFiles,
+  onOpenFileDialog,
   onCopySnippet,
   onCopyAllSnippets,
   onDownloadSnippets,
   maxPanel
 }: UploadPanelProps) {
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dropzoneRef = useRef<HTMLDivElement | null>(null);
-  const urlsRef = useRef<string[]>([]);
-
-  const handleFiles = useCallback((list: FileList | null) => {
-    if (!list || list.length === 0) return;
-    const next: BlobEntry[] = [];
-    for (let i = 0; i < list.length; i++) {
-      const file = list[i]!;
-      const url = URL.createObjectURL(file);
-      next.push({
-        id: `${file.name}-${file.size}-${file.lastModified}-${Math.random().toString(36).slice(2)}`,
-        file,
-        url,
-        snippet: snippetFor(file, url),
-      });
-      urlsRef.current.push(url);
-    }
-    onFilesChange([...next, ...files]);
-  }, [files, onFilesChange]);
-
-  function openFileDialog() {
-    fileInputRef.current?.click();
-  }
 
   // Dropzone interactions
   useEffect(() => {
@@ -77,7 +33,7 @@ export default function UploadPanel({
     const onDrop = (e: DragEvent) => {
       e.preventDefault();
       dz.classList.remove("dragover");
-      handleFiles(e.dataTransfer?.files ?? null);
+      onUploadFiles(e.dataTransfer?.files ?? null);
     };
     const onDragOver = (e: DragEvent) => {
       e.preventDefault();
@@ -95,22 +51,14 @@ export default function UploadPanel({
       dz.removeEventListener("dragover", onDragOver);
       dz.removeEventListener("dragleave", onDragLeave);
     };
-  }, [handleFiles]);
-
-  // Cleanup URLs on unmount
-  useEffect(() => {
-    const urls = urlsRef.current;
-    return () => {
-      urls.forEach((u) => URL.revokeObjectURL(u));
-    };
-  }, []);
+  }, [onUploadFiles]);
 
   return (
     <div className={`panel uploads ${maxPanel === "uploads" ? "panel-max" : ""}`}>
       <div className="panel-header">
         <div className="panel-title">Uploads</div>
         <div className="panel-actions">
-          <button className="icon-btn" title="Upload files" aria-label="Upload files" onClick={openFileDialog}>
+          <button className="icon-btn" title="Upload files" aria-label="Upload files" onClick={onOpenFileDialog}>
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 5 17 10"/><line x1="12" y1="5" x2="12" y2="21"/></svg>
           </button>
           <button className="icon-btn" title="Copy all snippets" aria-label="Copy all snippets" onClick={onCopyAllSnippets}>
@@ -129,8 +77,8 @@ export default function UploadPanel({
           tabIndex={0}
           role="button"
           aria-label="Drop files here or press Enter to browse"
-          onClick={(e) => { const target = e.target as HTMLElement; if (target.closest(".file-item")) return; openFileDialog(); }}
-          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") openFileDialog(); }}
+          onClick={(e) => { const target = e.target as HTMLElement; if (target.closest(".file-item")) return; onOpenFileDialog(); }}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenFileDialog(); }}
         >
           {files.length === 0 ? (
             <p>Drop files here or click to browse</p>
@@ -159,14 +107,6 @@ export default function UploadPanel({
             </ul>
           )}
         </div>
-        <input
-          ref={fileInputRef}
-          id="file-input"
-          type="file"
-          multiple
-          hidden
-          onChange={(e) => { handleFiles(e.currentTarget.files); e.currentTarget.value = ""; }}
-        />
         <p className="hint">Tip: Click a file to copy its Markdown snippet, then paste it into the editor.</p>
       </div>
     </div>

--- a/components/file-utils.ts
+++ b/components/file-utils.ts
@@ -1,0 +1,17 @@
+export function formatBytes(bytes: number) {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"] as const;
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+export function isImage(file: File) {
+  return file.type.startsWith("image/");
+}
+
+export function snippetFor(file: File, url: string) {
+  const safeName = file.name.replace(/\]/g, ")");
+  if (isImage(file)) return `![${safeName}](${url})`;
+  return `[${safeName}](${url})`;
+}

--- a/components/types.ts
+++ b/components/types.ts
@@ -1,0 +1,6 @@
+export interface BlobEntry {
+  id: string;
+  file: File;
+  url: string;
+  snippet: string;
+}


### PR DESCRIPTION
This PR addresses a code health issue where `openFileDialog` in `DawnMark.tsx` was using an unattached `fileInputRef`, making the function dead code.
By moving the file handling logic up to the parent `DawnMark` component, we not only fix the dead code but also enable the "Upload files" button in the `EditorPanel` to function correctly (previously it did nothing).
This also simplifies `UploadPanel` by removing duplicated logic and state.
Shared types and utilities were extracted to `components/types.ts` and `components/file-utils.ts` respectively.

---
*PR created automatically by Jules for task [17584434711143182606](https://jules.google.com/task/17584434711143182606) started by @7sg56*