### PR TITLE
🧹 Remove unused editorRef from MonacoEditor

### DIFF
--- a/components/MonacoEditor.tsx
+++ b/components/MonacoEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Editor } from "@monaco-editor/react";
 
 interface MonacoEditorProps {
@@ -14,8 +14,6 @@ export default function MonacoEditor({
   onChange,
   className = ""
 }: MonacoEditorProps) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const editorRef = useRef<any>(null);
   const [theme, setTheme] = useState('vs-dark');
   const [isClient, setIsClient] = useState(false);
 
@@ -49,8 +47,6 @@ export default function MonacoEditor({
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleEditorDidMount = (editor: any) => {
-    editorRef.current = editor;
-    
     // Configure editor options
     editor.updateOptions({
       minimap: { enabled: false },


### PR DESCRIPTION
🎯 **What:** Removed the unused `editorRef` variable and its associated logic in `components/MonacoEditor.tsx`.
💡 **Why:** Improving code maintainability and readability by removing dead code.
✅ **Verification:** Manually verified the file content. Verified that all editor configuration options are still applied via both the `options` prop and the `handleEditorDidMount` callback (minus the unused ref assignment). Received a successful code review.
✨ **Result:** Cleaner code without any change in functionality or appearance.

---
*PR created automatically by Jules for task [11816485340750707168](https://jules.google.com/task/11816485340750707168) started by @7sg56*