### PR TITLE
⚡ Optimize useIsMobile resize listener with debounce

### DIFF
--- a/__tests__/hooks/useIsMobile.test.ts
+++ b/__tests__/hooks/useIsMobile.test.ts
@@ -1,0 +1,83 @@
+
+import { renderHook, act } from '@testing-library/react';
+import { useIsMobile } from '../../hooks/useIsMobile';
+
+describe('useIsMobile', () => {
+  let innerWidthSpy: jest.Mock;
+  const originalInnerWidth = window.innerWidth;
+
+  beforeEach(() => {
+    // Reset spy
+    innerWidthSpy = jest.fn(() => 1000); // Desktop by default
+
+    // Mock window.innerWidth
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      get: innerWidthSpy,
+    });
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Restore original window.innerWidth
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: originalInnerWidth,
+    });
+    jest.useRealTimers();
+  });
+
+  it('correctly updates isMobile when window is resized', () => {
+    const { result } = renderHook(() => useIsMobile(768));
+
+    // Initially desktop (1000px)
+    expect(result.current.isMobile).toBe(false);
+
+    // Resize to mobile
+    act(() => {
+      innerWidthSpy.mockReturnValue(500);
+      window.dispatchEvent(new Event('resize'));
+      // Advance timer for potential debounce
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(result.current.isMobile).toBe(true);
+
+    // Resize back to desktop
+    act(() => {
+      innerWidthSpy.mockReturnValue(1000);
+      window.dispatchEvent(new Event('resize'));
+      // Advance timer for potential debounce
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(result.current.isMobile).toBe(false);
+  });
+
+  it('counts how many times innerWidth is accessed during rapid resize events (Performance Check)', () => {
+    const { result } = renderHook(() => useIsMobile());
+
+    // Clear mock calls to focus on resize events
+    innerWidthSpy.mockClear();
+
+    console.log('Simulating 100 resize events...');
+
+    // Simulate 100 rapid resize events
+    act(() => {
+      for (let i = 0; i < 100; i++) {
+        window.dispatchEvent(new Event('resize'));
+      }
+      // If debounce is implemented, we might need to advance timers
+      jest.advanceTimersByTime(1000);
+    });
+
+    const resizeCalls = innerWidthSpy.mock.calls.length;
+
+    console.log(`Resize triggered innerWidth accesses: ${resizeCalls}`);
+
+    // In unoptimized version, this should be >= 100
+    // In optimized version (debounce), this should be small (e.g. 1)
+  });
+});

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -7,19 +7,29 @@ export function useIsMobile(breakpoint: number = 768) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
     const checkIsMobile = () => {
       setIsMobile(window.innerWidth < breakpoint);
       setIsLoading(false);
+    };
+
+    const handleResize = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(checkIsMobile, 100);
     };
 
     // Check on mount
     checkIsMobile();
 
     // Add event listener for resize
-    window.addEventListener("resize", checkIsMobile);
+    window.addEventListener("resize", handleResize);
 
     // Cleanup
-    return () => window.removeEventListener("resize", checkIsMobile);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      clearTimeout(timeoutId);
+    };
   }, [breakpoint]);
 
   return { isMobile, isLoading };


### PR DESCRIPTION
This PR optimizes the `useIsMobile` hook by debouncing the resize event listener.

**Changes:**
- Implemented a 100ms debounce using `setTimeout` inside the `useEffect` hook.
- Added a new test file `__tests__/hooks/useIsMobile.test.ts` that:
  - Verifies the `isMobile` state updates correctly when the window is resized.
  - Benchmarks the number of internal `checkIsMobile` calls (proxied by `window.innerWidth` access) during rapid resize events.

**Performance Impact:**
- **Baseline:** Without optimization, rapid resizing triggered `checkIsMobile` ~100 times for 100 events.
- **Optimized:** With debounce, it triggers ~1 time for the same sequence.

This reduces unnecessary React state updates and layout thrashing during window resizing.

---
*PR created automatically by Jules for task [2724298069260166018](https://jules.google.com/task/2724298069260166018) started by @7sg56*