### PR TITLE
Fix setState in useEffect in MonacoEditor by refactoring to dynamic import

### DIFF
--- a/components/MonacoEditor.tsx
+++ b/components/MonacoEditor.tsx
@@ -1,139 +1,29 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { Editor } from "@monaco-editor/react";
+import React from "react";
+import dynamic from "next/dynamic";
+import { MonacoEditorProps } from "./types";
 
-interface MonacoEditorProps {
-  value: string;
-  onChange: (value: string) => void;
-  className?: string;
-}
+const MonacoEditorClient = dynamic(() => import("./MonacoEditorClient"), {
+  ssr: false,
+  loading: () => (
+    <div className="monaco-loading">
+      <div className="loading-text">Loading editor...</div>
+    </div>
+  ),
+});
 
 export default function MonacoEditor({
   value,
   onChange,
   className = ""
 }: MonacoEditorProps) {
-  const [theme, setTheme] = useState('vs-dark');
-  const [isClient, setIsClient] = useState(false);
-
-  // Check if we're on the client side
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsClient(true);
-  }, []);
-
-  // Detect theme from HTML class
-  useEffect(() => {
-    if (!isClient) return;
-    
-    const updateTheme = () => {
-      const isDark = document.documentElement.classList.contains('dark') || 
-                    !document.documentElement.classList.contains('light');
-      setTheme(isDark ? 'vs-dark' : 'vs');
-    };
-
-    updateTheme();
-    
-    // Watch for theme changes
-    const observer = new MutationObserver(updateTheme);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class']
-    });
-
-    return () => observer.disconnect();
-  }, [isClient]);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleEditorDidMount = (editor: any) => {
-    // Configure editor options
-    editor.updateOptions({
-      minimap: { enabled: false },
-      scrollBeyondLastLine: false,
-      wordWrap: 'on',
-      lineNumbers: 'off',
-      glyphMargin: false,
-      folding: false,
-      lineDecorationsWidth: 0,
-      lineNumbersMinChars: 0,
-      renderLineHighlight: 'none',
-      selectOnLineNumbers: false,
-      roundedSelection: false,
-      readOnly: false,
-      cursorStyle: 'line',
-      automaticLayout: true,
-      fontSize: 14,
-      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-      lineHeight: 24,
-      padding: { top: 16, bottom: 16 },
-      scrollbar: {
-        vertical: 'auto',
-        horizontal: 'auto',
-        useShadows: false,
-        verticalHasArrows: false,
-        horizontalHasArrows: false,
-      },
-    });
-
-    // Language is already set via defaultLanguage prop
-  };
-
-  const handleEditorChange = (value: string | undefined) => {
-    if (value !== undefined) {
-      onChange(value);
-    }
-  };
-
-
-  // Show loading state during SSR
-  if (!isClient) {
-    return (
-      <div className={`monaco-editor-container ${className}`}>
-        <div className="monaco-loading">
-          <div className="loading-text">Loading editor...</div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className={`monaco-editor-container ${className}`}>
-      <Editor
-        height="100%"
-        width="100%"
-        defaultLanguage="markdown"
+      <MonacoEditorClient
         value={value}
-        onChange={handleEditorChange}
-        onMount={handleEditorDidMount}
-        theme={theme}
-        options={{
-          minimap: { enabled: false },
-          scrollBeyondLastLine: false,
-          wordWrap: 'on',
-          lineNumbers: 'off',
-          glyphMargin: false,
-          folding: false,
-          lineDecorationsWidth: 0,
-          lineNumbersMinChars: 0,
-          renderLineHighlight: 'none',
-          selectOnLineNumbers: false,
-          roundedSelection: false,
-          readOnly: false,
-          cursorStyle: 'line',
-          automaticLayout: true,
-          fontSize: 14,
-          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-          lineHeight: 24,
-          padding: { top: 16, bottom: 16 },
-          scrollbar: {
-            vertical: 'auto',
-            horizontal: 'auto',
-            useShadows: false,
-            verticalHasArrows: false,
-            horizontalHasArrows: false,
-          },
-        }}
+        onChange={onChange}
+        className={className}
       />
     </div>
   );

--- a/components/MonacoEditorClient.tsx
+++ b/components/MonacoEditorClient.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Editor } from "@monaco-editor/react";
+import { MonacoEditorProps } from "./types";
+
+export default function MonacoEditorClient({
+  value,
+  onChange,
+}: MonacoEditorProps) {
+  const [theme, setTheme] = useState('vs-dark');
+
+  // Detect theme from HTML class
+  useEffect(() => {
+    const updateTheme = () => {
+      const isDark = document.documentElement.classList.contains('dark') ||
+                    !document.documentElement.classList.contains('light');
+      setTheme(isDark ? 'vs-dark' : 'vs');
+    };
+
+    updateTheme();
+
+    // Watch for theme changes
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleEditorDidMount = (editor: any) => {
+    // Configure editor options
+    editor.updateOptions({
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      wordWrap: 'on',
+      lineNumbers: 'off',
+      glyphMargin: false,
+      folding: false,
+      lineDecorationsWidth: 0,
+      lineNumbersMinChars: 0,
+      renderLineHighlight: 'none',
+      selectOnLineNumbers: false,
+      roundedSelection: false,
+      readOnly: false,
+      cursorStyle: 'line',
+      automaticLayout: true,
+      fontSize: 14,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+      lineHeight: 24,
+      padding: { top: 16, bottom: 16 },
+      scrollbar: {
+        vertical: 'auto',
+        horizontal: 'auto',
+        useShadows: false,
+        verticalHasArrows: false,
+        horizontalHasArrows: false,
+      },
+    });
+
+    // Language is already set via defaultLanguage prop
+  };
+
+  const handleEditorChange = (value: string | undefined) => {
+    if (value !== undefined) {
+      onChange(value);
+    }
+  };
+
+  return (
+    <Editor
+      height="100%"
+      width="100%"
+      defaultLanguage="markdown"
+      value={value}
+      onChange={handleEditorChange}
+      onMount={handleEditorDidMount}
+      theme={theme}
+      options={{
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        wordWrap: 'on',
+        lineNumbers: 'off',
+        glyphMargin: false,
+        folding: false,
+        lineDecorationsWidth: 0,
+        lineNumbersMinChars: 0,
+        renderLineHighlight: 'none',
+        selectOnLineNumbers: false,
+        roundedSelection: false,
+        readOnly: false,
+        cursorStyle: 'line',
+        automaticLayout: true,
+        fontSize: 14,
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        lineHeight: 24,
+        padding: { top: 16, bottom: 16 },
+        scrollbar: {
+          vertical: 'auto',
+          horizontal: 'auto',
+          useShadows: false,
+          verticalHasArrows: false,
+          horizontalHasArrows: false,
+        },
+      }}
+    />
+  );
+}

--- a/components/types.ts
+++ b/components/types.ts
@@ -4,3 +4,9 @@ export interface BlobEntry {
   url: string;
   snippet: string;
 }
+
+export interface MonacoEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}


### PR DESCRIPTION
Refactored `MonacoEditor` to use `next/dynamic` with `ssr: false` instead of manual hydration checks with `useEffect` and `useState`. This eliminates the need to set state inside `useEffect` (which was triggering a linter warning) and leverages Next.js built-in support for client-only components.

Changes:
1.  **Moved Implementation**: The core editor logic (Monaco Editor setup, theme handling, event listeners) was moved to a new component `components/MonacoEditorClient.tsx`.
2.  **Dynamic Import**: `components/MonacoEditor.tsx` now serves as a wrapper that dynamically imports `MonacoEditorClient` with a loading fallback.
3.  **Type Safety**: Introduced `MonacoEditorProps` in `components/types.ts` to share prop definitions between the wrapper and the implementation.
4.  **Cleanup**: Removed the `isClient` state variable and the associated `useEffect` hook, simplifying the component lifecycle.


---
*PR created automatically by Jules for task [8940032872772181959](https://jules.google.com/task/8940032872772181959) started by @7sg56*