### PR TITLE
⚡ Optimize Dropzone Event Listeners in UploadPanel

### DIFF
--- a/components/DawnMark.tsx
+++ b/components/DawnMark.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import DOMPurify from "dompurify";
 import { Marked } from "marked";
 import { markedHighlight } from "marked-highlight";
@@ -85,7 +85,7 @@ export default function DawnMark() {
     };
   }, []);
 
-  function handleFiles(list: FileList | null) {
+  const handleFiles = useCallback((list: FileList | null) => {
     if (!list || list.length === 0) return;
     const next: BlobEntry[] = [];
     for (let i = 0; i < list.length; i++) {
@@ -100,7 +100,7 @@ export default function DawnMark() {
       urlsRef.current.push(url);
     }
     setFiles((prev) => [...next, ...prev]);
-  }
+  }, []);
 
 
   function openFileDialog() {

--- a/components/UploadPanel.tsx
+++ b/components/UploadPanel.tsx
@@ -25,6 +25,11 @@ export default function UploadPanel({
   maxPanel
 }: UploadPanelProps) {
   const dropzoneRef = useRef<HTMLDivElement | null>(null);
+  const onUploadFilesRef = useRef(onUploadFiles);
+
+  useEffect(() => {
+    onUploadFilesRef.current = onUploadFiles;
+  });
 
   // Dropzone interactions
   useEffect(() => {
@@ -33,7 +38,7 @@ export default function UploadPanel({
     const onDrop = (e: DragEvent) => {
       e.preventDefault();
       dz.classList.remove("dragover");
-      onUploadFiles(e.dataTransfer?.files ?? null);
+      onUploadFilesRef.current(e.dataTransfer?.files ?? null);
     };
     const onDragOver = (e: DragEvent) => {
       e.preventDefault();
@@ -51,7 +56,7 @@ export default function UploadPanel({
       dz.removeEventListener("dragover", onDragOver);
       dz.removeEventListener("dragleave", onDragLeave);
     };
-  }, [onUploadFiles]);
+  }, []);
 
   return (
     <div className={`panel uploads ${maxPanel === "uploads" ? "panel-max" : ""}`}>


### PR DESCRIPTION
This PR addresses a performance inefficiency in `UploadPanel.tsx` where dropzone event listeners were being re-created on every render due to an unstable `onUploadFiles` prop and strict dependency array rules.

Changes:
1.  **DawnMark.tsx**: Wrapped `handleFiles` in `useCallback` to provide a stable function identity.
2.  **UploadPanel.tsx**: Used a `useRef` to hold the current `onUploadFiles` callback. This allows the effect responsible for `addEventListener` to run only once on mount (empty dependency array), while still accessing the latest callback via `ref.current`.

This optimization ensures that typing in the editor (which triggers frequent re-renders of the parent `DawnMark` component) does not cause expensive DOM operations in the `UploadPanel`.

---
*PR created automatically by Jules for task [16042538822938959075](https://jules.google.com/task/16042538822938959075) started by @7sg56*