### PR TITLE
🧹 Remove redundant marked configuration

### DIFF
--- a/components/DawnMark.tsx
+++ b/components/DawnMark.tsx
@@ -34,11 +34,6 @@ export default function DawnMark() {
   const urlsRef = useRef<string[]>([]);
   const [toast, setToast] = useState<string>("");
 
-  // Configure global marked instance once (GFM, breaks, no syntax highlighting)
-  useEffect(() => {
-    marked.use({ gfm: true, breaks: false });
-  }, []);
-
 
   // Render markdown -> preview with KaTeX auto-render
   useEffect(() => {


### PR DESCRIPTION
Removed redundant `useEffect` that configured `marked` in `components/DawnMark.tsx`. The configuration is already handled at the module level. Verified with tests and frontend preview check.

---
*PR created automatically by Jules for task [6113588752686348264](https://jules.google.com/task/6113588752686348264) started by @7sg56*